### PR TITLE
ci(golangci-lint): setup and add badge to README.md

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0
+          version: v2.0.2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,65 +1,54 @@
+# .golangci.toml
 version = "2"
 
 [linters]
   default = "all"
-
   disable = [
-    "lll",           # Line length (manage via formatters instead)
-    "dupl",          # Code duplication (high false positives)
-    "funlen",        # Function length (managed by cognitive complexity checks)
-    "nestif",        # Nested ifs (covered by gocritic)
-    "wsl",           # Whitespace (handled by gofumpt)
-    "gochecknoinits", # Init functions (sometimes necessary)
-    "exhaustruct"    # Enforces to pass all fields to a structure
+    "lll",
+    "dupl",
+    "funlen",
+    "nestif",
+    "wsl",
+    "gochecknoinits",
+    "exhaustruct",
   ]
 
   [linters.settings]
     [linters.settings.gocritic]
-      enabledTags = ["performance", "style", "experimental"]
-      disabledLinters = ["hugeParam"]
+      enabled-tags = ["performance", "style", "experimental"]
+      disabled-checks = ["hugeParam"]
 
     [linters.settings.gocyclo]
-      min-complexity = 15  # Default 30, stricter cyclomatic complexity
+      min-complexity = 15  # Default is 30 (we are more strict)
 
     [linters.settings.gocognit]
-      min-complexity = 15  # Default 30, stricter cognitive complexity
-
-    [linters.settings.maligned]
-      suggestNewOrder = true
+      min-complexity = 15  # Default is 30 (we are more strict)
 
     [linters.settings.prealloc]
       simple = true
       range-loops = true
-      maps = true
 
     [linters.settings.errcheck]
-      checkTypeAssertions = true
-      checkAssignToBlank = true
+      check-type-assertions = true
+      check-blank = true
 
     [linters.settings.depguard.rules.main]
-    list-mode = "lax"
-    allow = [
-      "botex/pkg/logger",
-      "botex/pkg/message",
-      "go.mau.fi/whatsmeow/types"
-    ]
+      list-mode = "lax"
+      allow = [
+        "botex/pkg/logger",
+        "botex/pkg/message",
+        "go.mau.fi/whatsmeow/types"
+      ]
 
     [linters.settings.revive]
-    rules = [
-      { name = "exported", disabled = true } # This enforces comments on exported functions
-    ]
+      rules = [
+        { name = "exported", disabled = true }
+      ]
 
 [formatters]
   enable = ["gofumpt", "goimports", "gci"]
   [formatters.settings.gci]
-    sections = ["standard", "default", "prefix(github.com/your-project)"]
-
-[issues]
-  # Here 0 means unlimited
-  max-issues-per-linter = 0
-  max-same-issues = 0
-  fix = true                 # Auto-fix where possible
-  uniq-by-line = false       # Show all issues per line
+    sections = ["standard", "default", "prefix(github.com/totallynotdavid/BoTeX)"]
 
 [run]
   timeout = "5m"
@@ -68,16 +57,10 @@ version = "2"
   modules-download-mode = "readonly"
   allow-parallel-runners = true
 
+[issues]
+  max-issues-per-linter = 0
+  max-same-issues = 0
+  fix = true
+
 [severity]
-  default = "error"  # Treat all findings as errors
-
-[linters.exclusions]
-  generated = "strict"  # Strictly ignore generated files
-  warn-unused = true    # Warn about unused excludes
-
-# Output configuration
-[output]
-  formatter = "colored-line-number"
-  print-issued-lines = true
-  print-linter-name = true
-  sort-order = ["file"]
+  default = "error"

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ build:
 
 # Format & Lint
 lint:
-	golangci-lint fmt && golangci-lint run --fix
+	golangci-lint config verify && golangci-lint fmt && golangci-lint run --fix

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BoTeX
 
-[![CodeQL](https://github.com/totallynotdavid/BoTeX/actions/workflows/codeql.yml/badge.svg)](https://github.com/totallynotdavid/BoTeX/actions/workflows/codeql.yml)
+[![CodeQL](https://github.com/totallynotdavid/BoTeX/actions/workflows/codeql.yml/badge.svg)](https://github.com/totallynotdavid/BoTeX/actions/workflows/codeql.yml) [![lint-and-testing](https://github.com/totallynotdavid/BoTeX/actions/workflows/golangci-lint.yml/badge.svg)](https://github.com/totallynotdavid/BoTeX/actions/workflows/golangci-lint.yml)
 
 BoTeX is a WhatsApp bot that renders LaTeX equations into images. I created this project while learning Go, drawing inspiration from how [matterbridge](https://github.com/42wim/matterbridge) implements WhatsApp integration using the [whatsmeow](https://github.com/tulir/whatsmeow) library. While it currently has a limited set of commands (`!latex` for rendering equations and `!help` for viewing available commands), it serves as a simple example of building a WhatsApp bot in Go.
 


### PR DESCRIPTION
This pull request includes the addition of a new GitHub Actions workflow for running `golangci-lint` and updates to the `README.md` file to include a badge for this new workflow.

### GitHub Actions Workflow:

* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48R1-R24): Added a new workflow configuration for `golangci-lint` that runs on `workflow_dispatch`, `push` to the `master` branch, and `pull_request`. This workflow sets up Go and runs `golangci-lint` using the specified version.

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated to include a badge for the new `golangci-lint` workflow, providing visibility into the linting status directly from the README.