### PR TITLE
docs(auth): add README with module overview, schema, and API usage

### DIFF
--- a/pkg/auth/README.md
+++ b/pkg/auth/README.md
@@ -75,7 +75,7 @@ fmt.Println(result.Allowed, result.Reason)
 // or false, "Command not allowed for your rank"
 ```
 
-**RegisterUser(ctx, userID, rank, registeredBy)** -> `error`: Adds new authorized user:
+**RegisterUser(ctx, userID, rank, registeredBy)** -> `error`: Adds new authorized user.
 
 Example usage:
 


### PR DESCRIPTION
This patch introduces comprehensive documentation for the `auth` module in `pkg/auth/README.md`.
The README explains the module’s purpose, data model, schema, and provides usage examples to help developers work with authentication and authorization in the bot system.

Changes:

* Describe module responsibilities
  * Manages user/group permissions and integrates with the bot’s database.

* Document data model
  * Users, groups, and ranks with field definitions and meanings.

* Add database schema details
  * Default schema and predefined ranks with permission structure.

* Provide API reference
  * Method signatures, parameters, and logic flow for core functions (`CheckPermission`, `RegisterUser`, `RegisterGroup`).

* Include usage examples
  * Demonstrates permission checks, user registration, and group registration.